### PR TITLE
Add support for IW610

### DIFF
--- a/boards/nxp/mimxrt1060_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1060_evk/doc/index.rst
@@ -438,7 +438,7 @@ Shield for M.2 Wi-Fi and BT Interface
 Rev C version is tested with :ref:`nxp_m2_wifi_bt` shield to attach any M.2 module
 with BT HCI UART interface and Wi-Fi SDIO interface. The shield binds the required NXP
 HCI driver or SDIO driver to perform firmware-load and other setup configurations
-for NXP SoC IW416/IW612.
+for NXP SoC IW416/IW612/IW610.
 
 Troubleshooting
 ===============

--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -55,7 +55,34 @@ endif # WIFI
 
 endif # SHIELD_NXP_M2_2EL_WIFI_BT
 
-if (BT_NXP_IW416) || (BT_NXP_NW612) || (NXP_IW416) || (NXP_IW61X)
+if SHIELD_NXP_M2_2LL_WIFI_BT
+
+if BT
+
+choice BT_NXP_MODULE
+	default BT_NXP_IW610
+endchoice
+
+endif # BT
+
+if WIFI
+
+config WIFI_NXP
+	default y
+
+choice NXP_WIFI_PART
+	default NXP_IW610
+endchoice
+
+choice NXP_IW610_MODULE
+	default NXP_IW610_MURATA_2LL_M2
+endchoice
+
+endif # WIFI
+
+endif # SHIELD_NXP_M2_2LL_WIFI_BT
+
+if (BT_NXP_IW416) || (BT_NXP_NW612) || (BT_NXP_IW610) || (NXP_IW416) || (NXP_IW61X) || (NXP_IW610)
 
 if BT
 

--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.shield
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.shield
@@ -6,3 +6,6 @@ config SHIELD_NXP_M2_1XK_WIFI_BT
 
 config SHIELD_NXP_M2_2EL_WIFI_BT
 	def_bool $(shields_list_contains,nxp_m2_2el_wifi_bt)
+
+config SHIELD_NXP_M2_2LL_WIFI_BT
+	def_bool $(shields_list_contains,nxp_m2_2ll_wifi_bt)

--- a/boards/shields/nxp_m2_wifi_bt/doc/index.rst
+++ b/boards/shields/nxp_m2_wifi_bt/doc/index.rst
@@ -10,22 +10,26 @@ This Zephyr shield is tested with the following M.2 modules and hardware for Wi-
 
 - Embedded Artist 1XK module - uses Murata 1XK radio module with NXP IW416 chipset
 - Embedded Artist 2EL module - uses Murata 2EL radio module with NXP IW612 chipset
+- Embedded Artist 2LL module - uses Murata 2LL radio module with NXP IW610 chipset
 
 More information about supported chipsets, radio modules and M.2 modules can be found in below links,
 
 - `IW612 NXP Chipset <https://www.nxp.com/products/IW612>`_
 - `IW416 NXP Chipset <https://www.nxp.com/products/IW416>`_
+- `IW610 NXP Chipset <https://www.nxp.com/products/IW610>`_
 - `2EL Murata Radio Module <https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2el>`_
 - `1XK Murata Radio Module  <https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type1xk>`_
+- `2LL Murata Radio Module <https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2ll>`_
 - `1XK Embedded Artist Module <https://www.embeddedartists.com/products/1xk-m-2-module>`_
 - `2EL Embedded Artist Module <https://www.embeddedartists.com/products/2el-m-2-module>`_
+- `2LL Embedded Artist Module <https://www.embeddedartists.com/products/2ll-m-2-module>`_
 
 Requirements
 ************
 
 To use the shield, below requirements needs to be satisfied.
 
-- M.2 module with BT HCI UART and SDIO Interface with NXP IW416 or IW612 SoC support.
+- M.2 module with BT HCI UART and SDIO Interface with NXP IW416 or IW612 or IW610 SoC support.
 - Host platform shall have compatible M.2 interface slot.
 - For Coex (Wi-Fi + BT), UART driver that supports UART RTS line control to wakeup BT CPU from sleep.
 - To use default Bluetooth-Shell app it needs ~490KB flash & ~130KB RAM memory.
@@ -56,6 +60,7 @@ Below are the supported shields to be used with ``--shield <option>`` when you i
 
 - ``nxp_m2_1xk_wifi_bt``: For Wi-Fi/Bluetooth samples to work with NXP IW416 SoC
 - ``nxp_m2_2el_wifi_bt``: For Wi-Fi/Bluetooth samples to work with NXP IW612 SoC
+- ``nxp_m2_2ll_wifi_bt``: For Wi-Fi/Bluetooth samples to work with NXP IW610 SoC
 
 For example:
 
@@ -69,4 +74,10 @@ For example:
    :zephyr-app: samples/net/wifi/shell
    :board: mimxrt1060_evk@C//qspi
    :shield: nxp_m2_2el_wifi_bt
+   :goals: build
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/net/wifi/shell
+   :board: mimxrt1060_evk@C//qspi
+   :shield: nxp_m2_2ll_wifi_bt
    :goals: build

--- a/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/nxp_m2_2ll_wifi_bt.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,bt-hci = &bt_hci_uart;
+	};
+};
+
+&m2_hci_bt_uart {
+	current-speed = <115200>;
+	status = "okay";
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+		status = "okay";
+
+		m2_bt_module {
+			compatible = "nxp,bt-hci-uart";
+			hci-operation-speed = <3000000>;
+			hw-flow-control;
+			fw-download-primary-speed = <115200>;
+			fw-download-secondary-speed = <3000000>;
+			fw-download-secondary-flowcontrol;
+		};
+	};
+};
+
+&m2_wifi_sdio {
+	nxp_wifi {
+		compatible = "nxp,wifi";
+		status = "okay";
+	};
+};

--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -80,6 +80,13 @@ config NXP_88W8801
 	  More information about 88W8801 device you can find on
 	  https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/2-4-ghz-single-band-1x1-wi-fi-4-802-11n-solution:88W8801
 
+config NXP_IW610
+	bool "NXP IW610"
+	help
+	  Enable NXP IW610 Wi-Fi connectivity,
+	  More information about IW610 device you can find on
+	  https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/2-4-5ghz-dual-band-1x1-wi-fi-6-plus-bluetooth-low-energy-5-4-plus-802-15-4-tri-radio-solution:IW610
+
 endchoice
 
 choice NXP_88W8987_MODULE
@@ -337,7 +344,7 @@ config NXP_88W8801_MURATA_2DS_USD
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2ds
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/usd-m2-adapter
 
-config NXP_88W8801_MURATA_2DS_USD
+config NXP_88W8801_MURATA_2DS_M2
 	bool "NXP MURATA-2DS-M2"
 	help
 	  Murata Type 2DS is a small high-performance module (integrated PCB antenna)
@@ -346,6 +353,36 @@ config NXP_88W8801_MURATA_2DS_USD
 
 	  Detailed information about Murata Type 2DS module you can find on
 	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2ds
+
+endchoice
+
+choice NXP_IW610_MODULE
+	prompt "Select NXP IW610 module"
+	depends on NXP_IW610 && !NXP_WIFI_CUSTOM
+
+config NXP_IW610_MURATA_2LL_M2
+	bool "NXP IW610-MURATA-2LL-M2"
+	help
+	  Murata Type 2LL is a small and very high performance module based on NXP IW610G
+	  combo chipset which supports Wi-Fi™ 802.11a/b/g/n/ac/ax HE20 + Bluetooth®. 5.4
+	  Low Energy + 802.15.4 up to 114.7Mbps PHY data rate on Wi-Fi™ and 2Mbps PHY data
+	  rate on Bluetooth® Low Energy.
+
+	  Detailed information about Type 2LL module you can find on
+	  https://www.murata.com/en-us/products/connectivitymodule/wi-fi-bluetooth/overview/lineup/type2ll
+
+config NXP_IW610_RD_USD
+	bool "NXP IW610-RD-USD [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  The IW610 Family features a 1x1 Dual-band (2.4 GHz / 5 GHz) Wi-Fi 6 radio subsystem,
+	  offering improved network efficiency, reduced latency and extended range compared to
+	  previous Wi-Fi standards. Its Bluetooth LE radio supports a high-speed data rate of
+	  2 Mbit/s, along with long-range communication and extended advertising for network
+	  commissioning and sensor aggregation.
+
+	  Detailed information about Type RD USD module you can find on
+	  https://www.nxp.com/part/IW610CHN
 
 endchoice
 
@@ -655,7 +692,7 @@ config NXP_WIFI_11AX
 	default y
 	select NXP_WIFI_11AC
 	select NXP_WIFI_WMM
-	depends on NXP_RW610 || NXP_IW61X || NXP_WIFI_CUSTOM
+	depends on NXP_RW610 || NXP_IW61X || NXP_IW610 || NXP_WIFI_CUSTOM
 	help
 	  This option enables the use of 802.11ax support.
 
@@ -663,7 +700,7 @@ config NXP_WIFI_11AC
 	bool "802.11AC Support"
 	default y
 	select NXP_WIFI_WMM
-	depends on NXP_RW610 || NXP_IW61X || NXP_88W8987 || NXP_WIFI_CUSTOM
+	depends on NXP_RW610 || NXP_IW61X || NXP_88W8987 || NXP_IW610 || NXP_WIFI_CUSTOM
 	help
 	  This option enables the use of 802.11ac support.
 
@@ -761,6 +798,8 @@ config NXP_WIFI_CSI
 config NXP_WIFI_RESET
 	bool "Wi-Fi reset"
 	default y
+	imply NXP_WIFI_IND_DNLD if NXP_IW610
+	imply NXP_WIFI_IND_RESET if NXP_IW610
 	help
 	  This option is used to enable/disable/reset Wi-Fi.
 
@@ -780,7 +819,7 @@ config NXP_WIFI_UNII4_BAND_SUPPORT
 
 config NXP_WIFI_RECOVERY
 	bool "RECOVERY"
-	depends on NXP_RW610
+	depends on NXP_RW610 || NXP_IW610
 	help
 	  This option is used to enable wifi recovery support.
 
@@ -946,7 +985,7 @@ config NXP_WIFI_EU_VALIDATION
 	help
 	  This option enables EU Validation Support.
 
-if NXP_RW610 || NXP_IW61X
+if NXP_RW610 || NXP_IW61X || NXP_IW610
 
 config NXP_WIFI_CLOCKSYNC
 	bool "Clock sync using TSF latch"
@@ -957,14 +996,14 @@ config NXP_WIFI_CLOCKSYNC
 config NXP_WIFI_COMPRESS_TX_PWTBL
 	bool "Compress TX Power Table Support"
 	default y
-	depends on (NXP_RW610 || NXP_IW61X_REGION_WW)
+	depends on (NXP_RW610 || NXP_IW61X_REGION_WW || NXP_IW610)
 	help
 	  This option enables the use of Compress TX Power Table support.
 
 config NXP_WIFI_COMPRESS_RU_TX_PWTBL
 	bool "Compress RU TX Power Table Support"
 	default y
-	depends on (NXP_RW610 || NXP_IW61X_REGION_WW)
+	depends on (NXP_RW610 || NXP_IW61X_REGION_WW || NXP_IW610)
 	help
 	  This option enables the use of Compress RU TX Power Table support.
 
@@ -996,7 +1035,7 @@ config NXP_WIFI_FIPS
 
 config NXP_WIFI_OWE
 	bool "Opportunistic Wireless Encryption"
-	default y
+	default y if NXP_RW610
 	help
 	  This option enables Wi-Fi Opportunistic Wireless Encryption support
 	  in the Wi-Fi driver.
@@ -1013,7 +1052,7 @@ config NXP_WIFI_CUSTOM_CALDATA
 	help
 	  This option force to use custom calibration data.
 
-if NXP_88W8987 || NXP_IW416
+if NXP_88W8987 || NXP_IW416 || NXP_IW610
 
 config NXP_WIFI_FW_AUTO_RECONNECT
 	bool "Firmware Auto Reconnect"


### PR DESCRIPTION
Add Kconfig NXP_IW610, NXP_IW610_MURATA_2LL_M2, NXP_IW610_RD_USD.
Added seperate shield overlay for supported M.2 2LL module to enable BT or WIFI or Both.