### PR TITLE
modules: openthread: Add API to access Radio Spinel instance

### DIFF
--- a/modules/openthread/platform/radio_spinel.cpp
+++ b/modules/openthread/platform/radio_spinel.cpp
@@ -628,3 +628,8 @@ extern "C" void platformRadioProcess(otInstance *aInstance)
 	psSpinelDriver->Process(aInstance);
 	psRadioSpinel->Process(aInstance);
 }
+
+extern "C" void *platformGetRadioSpinel(void)
+{
+    return psRadioSpinel;
+}


### PR DESCRIPTION
Add platformGetRadioSpinel() function to allow external modules to access the Radio Spinel instance for vendor-specific commands.

This enables vendor extensions to send custom Spinel properties without modifying the core OpenThread platform code.