### PR TITLE
bluetooth: smp: Increase BT RX thread stack size when SMP is enabled

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -81,6 +81,7 @@ config BT_RX_STACK_SIZE
 	default 768 if BT_HCI_RAW
 	default 3092 if BT_MESH_GATT_CLIENT
 	default 2800 if BT_MESH_PB_GATT
+	default 2800 if BT_SMP
 	default 2600 if BT_MESH
 	default 2048 if BT_AUDIO
 	default 1200


### PR DESCRIPTION
When upgrading the BLE security level (e.g. "bt security 2"), the SMP layer performs an AES-CMAC computation as part of the pairing procedure. On platforms using a PSA crypto driver backend (NXP ELS/PKC), a single mcuxClPsaDriver_psa_driver_wrapper_mac_computeLayer() call consumes over 700 bytes of stack.

The BT RX thread (BT_RX_STACK_SIZE) defaults to 1200 bytes, which is not large enough to hold this computation on top of the existing SMP call chain.

Add a conditional default of 2800 bytes for BT_RX_STACK_SIZE when BT_SMP is enabled.