### PR TITLE
twister: limit fixture-only hardware to matching tests

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaredata.py
+++ b/scripts/pylib/twister/twisterlib/hardwaredata.py
@@ -29,6 +29,7 @@ class HardwareData:
     flash_with_test: bool = False
     flash_before: bool = False
     fixtures: list[str] = field(default_factory=list)
+    run_with_fixture_only: bool = False
     probe_id: str | None = None
     notes: str | None = None
     match: bool = False

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -273,6 +273,7 @@ class HardwareMap:
             serial_baud = dut.get('serial_baud', None) or dut.get('baud', None)
             product = dut.get('product')
             fixtures = dut.get('fixtures', [])
+            run_with_fixture_only = dut.get('run_with_fixture_only', False)
             connected = dut.get('connected') and ((serial or serial_pty) is not None)
             west_flash_cmd = dut.get('west_flash_cmd', "")
             if not connected:
@@ -294,6 +295,7 @@ class HardwareMap:
                               script_param=script_param,
                               flash_timeout=flash_timeout,
                               flash_with_test=flash_with_test,
+                              run_with_fixture_only=run_with_fixture_only,
                               west_flash_cmd=west_flash_cmd)
                 new_dut.fixtures = fixtures
                 new_dut.counter = 0

--- a/scripts/pylib/twister/twisterlib/hardwareutil.py
+++ b/scripts/pylib/twister/twisterlib/hardwareutil.py
@@ -111,6 +111,8 @@ class HardwareReservationManager:
         for d in self.hwm.duts:
             if d.platform != platform or (d.serial is None and d.serial_pty is None):
                 continue
+            if not fixture and d.run_with_fixture_only:
+                continue
             if fixture and not all(f in (f.split(sep=':')[0] for f in d.fixtures) for f in fixture):
                 continue
             matched_duts.append(d)

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -304,7 +304,8 @@ class TestInstance(StatusMixin):
         if testsuite_runnable := self.testsuite.harness in SUPPORTED_HARNESSES:
             if device_testing:
                 testsuite_runnable = HardwareReservationManager(
-                    hardware_map, self.platform.name, self.testsuite.harness_config).is_runnable()
+                    hardware_map, self.platform.name, self.testsuite.harness_config
+                ).is_runnable()
 
             elif fixture := self.testsuite.harness_config.fixture:
                 # if we have a fixture that is also being supplied on the

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -40,6 +40,8 @@ items:
       type: array
       items:
         type: string
+    run_with_fixture_only:
+      type: boolean
     flash_timeout:
       type: integer
     flash_with_test:

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -271,6 +271,7 @@ def test_hardwaremap_load():
   fixtures:
   - dummy fixture 1
   - dummy fixture 2
+  run_with_fixture_only: true
   connected: True
   serial: 'dummy'
 - id: id1
@@ -310,6 +311,7 @@ def test_hardwaremap_load():
             'flash_with_test': True,
             'serial_baud': 14400,
             'fixtures': ['dummy fixture 1', 'dummy fixture 2'],
+            'run_with_fixture_only': True,
             'connected': True,
             'serial': 'dummy',
             'serial_pty': None,
@@ -322,6 +324,7 @@ def test_hardwaremap_load():
             'flash_with_test': False,
             'serial_baud': 115200,
             'fixtures': [],
+            'run_with_fixture_only': False,
             'connected': True,
             'serial_pty': 'dummy',
         },

--- a/scripts/tests/twister/test_hardwareutil.py
+++ b/scripts/tests/twister/test_hardwareutil.py
@@ -58,6 +58,14 @@ def test_hardwareutil_reserve_dut(hwmap: HardwareMap):
     assert all(d.available == 0 for d in duts_with_core)
 
 
+def test_hardwareutil_run_with_fixture_only(hwmap: HardwareMap):
+    hwmap.duts[1].run_with_fixture_only = True
+    hwmgr = HardwareReservationManager(hwmap, platform='platform1', harness_config=HarnessConfig())
+
+    assert hwmgr._get_matched_duts('platform1', raise_exception=False) == [hwmap.duts[0]]
+    assert hwmgr._get_matched_duts('platform1', ['fixture1']) == [hwmap.duts[1]]
+
+
 def test_hardwareutil_reserve_dut_less_failures(hwmap: HardwareMap):
     hwmgr = HardwareReservationManager(hwmap, platform='platform1', harness_config=mock.Mock())
     # Set failures for DUTs

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -537,6 +537,41 @@ def test_testinstance_check_runnable(
     assert res == expected
 
 
+@pytest.mark.parametrize(
+    ('fixture', 'run_with_fixture_only', 'expected'),
+    [
+        (None, True, False),
+        (['fixture1'], True, True),
+        (['fixture2'], True, False),
+        (None, False, True),
+    ],
+)
+@pytest.mark.parametrize('testinstance', [{'testsuite_kind': 'tests'}], indirect=True)
+def test_testinstance_check_runnable_fixture_only_dut(
+    testinstance, fixture, run_with_fixture_only, expected
+):
+    testinstance.testsuite.harness = 'console'
+    testinstance.testsuite.build_only = False
+    testinstance.testsuite.slow = False
+    testinstance.testsuite.harness_config.fixture = fixture
+    dut = mock.Mock(
+        platform=testinstance.platform.name,
+        serial='dummy_serial',
+        serial_pty=None,
+        fixtures=['fixture1'],
+        run_with_fixture_only=run_with_fixture_only,
+    )
+    options = mock.Mock(
+        device_testing=True,
+        enable_slow=True,
+        filter='runnable',
+        fixture=[],
+        sim_name='qemu',
+    )
+
+    assert testinstance.check_runnable(options, mock.Mock(duts=[dut])) == expected
+
+
 TESTDATA_6 = [
     (True, 'build.log'),
     (False, ''),


### PR DESCRIPTION
## Summary

Add a `run_with_fixture_only` property to `hwmap.yaml` and use it in
Twister device selection.

When a DUT is marked with `run_with_fixture_only: true`, Twister now
uses that DUT only for tests that declare matching `fixture`
requirements. Tests without required fixtures are treated as not
runnable on that fixture-only DUT.

## Problem

Some hardware entries are intended only for fixture-dependent test
scenarios. Before this change, Twister could still consider those DUTs
for tests that do not request fixtures.

## Solution

- add `run_with_fixture_only` to the hwmap schema
- parse and store the property in hardware map data
- exclude fixture-only DUTs from non-fixture test selection
- keep fixture-only DUTs eligible when requested fixtures match
- add unit tests for schema/load and runnable selection behavior

## Testing

- `python -m pytest scripts/tests/twister/test_hardwaremap.py -q -k test_hardwaremap_load`
- `python -m pytest scripts/tests/twister/test_hardwareutil.py -q -k "run_with_fixture_only or reserve_duts"`
- `python -m pytest scripts/tests/twister/test_testinstance.py -q -k fixture_only_dut`
