### PR TITLE
dts: nxp: mcx: add #inputmux-cells to inputmux nodes

### DIFF
--- a/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa153.dtsi
@@ -271,6 +271,7 @@
 			reg = <0x40001000 0x1000>;
 			#mux-control-cells = <1>;
 			#mux-state-cells = <2>;
+			#inputmux-cells = <2>;
 		};
 
 		i3c0: i3c@40002000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa156.dtsi
@@ -334,6 +334,7 @@
 			reg = <0x40001000 0x1000>;
 			#mux-control-cells = <1>;
 			#mux-state-cells = <2>;
+			#inputmux-cells = <2>;
 		};
 
 		eqdc0: eqdc@400a7000 {

--- a/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxa344.dtsi
@@ -312,6 +312,7 @@
 			reg = <0x40001000 0x1000>;
 			#mux-control-cells = <1>;
 			#mux-state-cells = <2>;
+			#inputmux-cells = <2>;
 		};
 
 		eqdc0: eqdc@400a7000 {

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -720,6 +720,7 @@
 			reg = <0x40001000 0x1000>;
 			#mux-control-cells = <1>;
 			#mux-state-cells = <2>;
+			#inputmux-cells = <2>;
 		};
 
 		eqdc0: eqdc@400a7000 {

--- a/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxnx4x_common.dtsi
@@ -139,6 +139,7 @@
 		status = "disabled";
 		#mux-control-cells = <1>;
 		#mux-state-cells = <2>;
+		#inputmux-cells = <2>;
 	};
 
 	porta: pinmux@116000 {

--- a/dts/bindings/mux/nxp,inputmux.yaml
+++ b/dts/bindings/mux/nxp,inputmux.yaml
@@ -18,6 +18,10 @@ properties:
   "#mux-state-cells":
     const: 2
 
+  "#inputmux-cells":
+    type: int
+    const: 2
+
 mux-control-cells:
   # Serial number of the destination register inside its group. For
   # example, "index = 2" selects PINT_SEL2 within the PINTSEL group.
@@ -29,4 +33,12 @@ mux-state-cells:
   # inputmux connection value. Encodes BOTH the
   # destination register-group offset (high bits, PMUX_SHIFT and above)
   # AND the source / function ID (low bits).
+  - connection
+
+inputmux-cells:
+  # INPUTMUX channel selected on the target peripheral.
+  - channel
+  # inputmux connection value. Encodes BOTH the destination
+  # register-group offset (high bits) AND the source / function ID
+  # (low bits).
   - connection


### PR DESCRIPTION
## Description

The `nxp,lpc-ctimer` binding introduces an `inputmux-connections`
phandle-array property that uses `specifier-space: inputmux`. Consuming
that property requires the referenced `inputmux` node to declare a
matching `#inputmux-cells` count, otherwise devicetree cannot size the
cells following the phandle and the build fails with:

```
devicetree error: <Node /soc/inputmux@40001000 in
dts/arm/nxp/mcx/nxp_mcxa153.dtsi:269> lacks #inputmux-cells
CMake Error at cmake/modules/dts.cmake:326 (execute_process)
```

Neither the `inputmux` nodes nor the `nxp,inputmux` binding declared
`#inputmux-cells`, so the feature was unusable on any mcx SoC.

## Changes

- `dts/bindings/mux/nxp,inputmux.yaml`: declare the `#inputmux-cells`
  property (`type: int`, `const: 2`) and the `inputmux-cells` specifier
  names (`channel`, `connection`).
- Add `#inputmux-cells = <2>` to the `inputmux` nodes of the mcx SoCs
  that share the binding:
  - `nxp_mcxa153.dtsi`
  - `nxp_mcxa156.dtsi`
  - `nxp_mcxa344.dtsi`
  - `nxp_mcxaxx6_common.dtsi`
  - `nxp_mcxnx4x_common.dtsi`

## Fixes

Fixes the CMake devicetree build failure for
`tests/drivers/counter/counter_capture` on `frdm_mcxa153/mcxa153`, and
enables `inputmux-connections` usage on the other mcx SoCs.

## Verification

Validated the devicetree stage with `edtlib` (the library used by
`gen_defines.py` / `dts.cmake`) against the preprocessed board + test
overlay:

- `frdm_mcxa153`: `inputmux-connections` on `ctimer@40006000` resolves
  to target `inputmux@40001000` with cells decoded as
  `{'channel': 0, 'connection': 0x06000024}`, matching the overlay.
- `frdm_mcxa156`: `inputmux@40001000` parses with `#inputmux-cells = 2`.
